### PR TITLE
Jdbc failover url

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -55,7 +55,8 @@ spec:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
     - name: DB_URL
-      value: jdbc:oracle:thin:@a01dbfl048.adeo.no:1521/areq02
+      # samme host for main og backup - ønsker liknende setting som i prod for å sjekke at den fungerer som forventet
+      value: jdbc:oracle:thin:@(DESCRIPTION=(FAILOVER=on)(CONNECT_TIMEOUT=15)(RETRY_COUNT=20)(RETRY_DELAY=3)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=a01dbfl048.adeo.no)(PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=a01dbfl048.adeo.no)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=areq02)))
     - name: DB_USER_PATH
       value: /var/run/secrets/oracle/creds/username
     - name: DB_PASSWORD_PATH

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -55,7 +55,7 @@ spec:
     - name: SPRING_PROFILES_ACTIVE
       value: prod
     - name: DB_URL
-      value: jdbc:oracle:thin:@a01dbfl049.adeo.no:1521/arenap
+      value: jdbc:oracle:thin:@(DESCRIPTION=(FAILOVER=on)(CONNECT_TIMEOUT=15)(RETRY_COUNT=20)(RETRY_DELAY=3)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=a01dbfl049.adeo.no)(PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=a01dbfl048.adeo.no)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=arena_ha)))
     - name: DB_USER_PATH
       value: /var/run/secrets/oracle/creds/username
     - name: DB_PASSWORD_PATH

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: oracle.jdbc.driver.OracleDriver
+    driver-class-name: oracle.jdbc.OracleDriver
     hikari:
       maximum-pool-size: 20
       connection-test-query: "select 1 from dual"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

> For unngå nedetid på basen og applikasjonen, skal databasen til Arena flyttes til reservenoden - `a01dbfl048.adeo.no`- og vil kjøre der fra 7.mars kl 17:00 til 8.mars kl 17:00.
Dere som har connections mot arenap på `a01dbfl049.adeo.no` må sjekke at connectionstringen deres også inneholder info om reservenoden, slik at dere får koblet dere mot arenap også i angitt tidsrom.
I utgangspunktet skal denne flyttingen skje uten nedetid, men brudd og ustabilitet kan forekomme.
NB! Dette gjelder produksjonsmiljøet!
I tillegg vil også alle Q-miljøene til Arena være nede i tidsrommet flyttingen pågår.

https://nav-it.slack.com/archives/C06BW4WB54P/p1740393599501319

* Endrer service name fra arenap til arena_ha
* Korrigerer driver for å unngå warning i loggene